### PR TITLE
Convert new line chars into html break tags

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -77,11 +77,12 @@ export function buildLink(el) {
 }
 
 export function buildText(el) {
+  const value = el?.value?.replace(/\n/g, '<br>')
   if (el?.bold) {
-    return `<strong>${el?.value}</strong>`
+    return `<strong>${value}</strong>`
   }
   if (el?.italic) {
-    return `<em>${el?.value}</em>`
+    return `<em>${value}</em>`
   }
-  return el?.value
+  return value
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -39,7 +39,12 @@ test('check converting JSON object schema to HTML', () => {
       },
       {
         type: 'paragraph',
-        children: [{ type: 'text', value: 'This is test.' }],
+        children: [
+          {
+            type: 'text',
+            value: 'This is test. New\nlines\nare supported.',
+          },
+        ],
       },
       {
         type: 'heading',
@@ -79,5 +84,8 @@ test('check converting JSON object schema to HTML', () => {
   expect(document.querySelector('ul>li').textContent).toBe('item1')
   expect(document.querySelector('p em').textContent).toBe(
     'This is italicized text and '
+  )
+  expect(document.querySelector('p:nth-child(2)').innerHTML).toBe(
+    'This is test. New<br>lines<br>are supported.'
   )
 })


### PR DESCRIPTION
Thanks for the library, it's been very helpful 👍

We've found Shopify's rich text editor returns new line characters within text nodes which HTML ignores. This PR therefore converts them to break tags so the html renders more similarly to the editor UI.
