### PR TITLE
Add classes & newLineToBreak options

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,7 +18,8 @@
     "prettier/prettier": [
       "warn",
       {
-        "endOfLine": "lf"
+        "endOfLine": "lf",
+        "printWidth": 120
       }
     ]
   }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,8 +1,9 @@
 {
-	"tabWidth": 2,
-	"singleQuote": true,
-	"useTabs": false,
-	"semi": false,
-	"arrowParens": "avoid",
-	"endOfLine": "lf"
+  "tabWidth": 2,
+  "printWidth": 120,
+  "singleQuote": true,
+  "useTabs": false,
+  "semi": false,
+  "arrowParens": "avoid",
+  "endOfLine": "lf"
 }

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ convertSchemaToHtml(richTextResponse)
 ...
 ```
 
-To get scoped HTML pass either true or the name of a class(es) to use in your scoped css selectors. This allows for the rich text HTML to be easily styled.
+To get scoped HTML pass either true or the name of a class(es) to use in your scoped css selectors in the `scoped` property of the `options` parameter (options.scoped). This allows for the rich text HTML to be easily styled.
 
 ```javascript
 // scoped html
-convertSchemaToHtml(richTextResponse, true)
+convertSchemaToHtml(richTextResponse, { scoped: true })
 ```
 
 ```html
@@ -50,7 +50,7 @@ You can also pass in a custom class name to be used as the scoped class instead 
 
 ```javascript
 //scoped w/ custom class name
-convertSchemaToHtml(richTextResponse, 'rich-text-wrap')
+convertSchemaToHtml(richTextResponse, { scoped: 'rich-text-wrap' })
 ```
 
 ```html
@@ -62,6 +62,52 @@ convertSchemaToHtml(richTextResponse, 'rich-text-wrap')
   </ol>
   ...
 </div>
+```
+
+If you want to be more specific or are using something like Tailwind CSS you can pass a string of classes to be used with specific HTML elements to the `classes` property of the `options` parameter (options.classes). This makes it easy to write your own wrapper class to apply a default classlist to various elements.
+
+```javascript
+const options = {
+  scoped: false,
+  classes: {
+    p: 'mt-3 text-lg', // paragraph classes
+    h1: 'mb-4 text-2xl md:text-4xl', // heading1 classes
+    h2: 'mb-4 text-xl md:text-3xl', // heading2 classes
+    h3: 'mb-3 text-lg md:text-2xl', // heading3 classes
+    h4: 'mb-3 text-base md:text-lg', // heading4 classes
+    h5: 'mb-2.5 text-sm md:text-base', // heading5 classes
+    h6: 'mb-2 text-xs md:text-sm', // heading6 classes
+    ol: 'my-3 ml-3 flex flex-col gap-y-2', // order list classes
+    ul: 'my-3 ml-3 flex flex-col gap-y-2', // unordered list classes
+    li: 'text-sm md:text-base', // list item classes
+    a: 'underline text-blue-500 hover:text-blue-700', // anchor/link classes
+    bold: 'font-medium', // bold/strong classes
+    italic: 'font-italic', // italic/em classes
+  },
+}
+
+// Applying classes directly to elements
+convertSchemaToHtml(richTextResponse, options)
+```
+
+```html
+<!-- Output: -->
+<h1 class="mb-4 text-2xl md:text-4xl">Groceries</h1>
+<p class="mt-3 text-lg">
+  Here is my shopping list for various fruit to buy at
+  <a
+    href="https://grocerystore.com"
+    class="underline text-blue-500 hover:text-blue-700"
+  >
+    The Grocery Store
+  </a>
+</p>
+<ol class="my-3 ml-3 flex flex-col gap-y-2">
+  <li class="text-sm md:text-base">apples</li>
+  <li class="text-sm md:text-base">oranges</li>
+  <li class="text-sm md:text-base">bananas</li>
+</ol>
+...
 ```
 
 React/Hydrogen example:

--- a/README.md
+++ b/README.md
@@ -64,11 +64,12 @@ convertSchemaToHtml(richTextResponse, { scoped: 'rich-text-wrap' })
 </div>
 ```
 
-If you want to be more specific or are using something like Tailwind CSS you can pass a string of classes to be used with specific HTML elements to the `classes` property of the `options` parameter (options.classes). This makes it easy to write your own wrapper class to apply a default classlist to various elements.
+If you want to be more specific or are using something like Tailwind CSS you can pass a string of classes to be used with specific HTML elements to the `classes` property of the `options` parameter (options.classes). This makes it easy to write your own wrapper class to apply a default classlist to various elements. There is also an option to convert new line character's to `<br/>` ( You can create new lines using `shift + space` in Shopify's rich text editor).
 
 ```javascript
 const options = {
   scoped: false,
+  newLineToBreak: true, // convert new line character to <br/>
   classes: {
     p: 'mt-3 text-lg', // paragraph classes
     h1: 'mb-4 text-2xl md:text-4xl', // heading1 classes

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ const options = {
     ul: 'my-3 ml-3 flex flex-col gap-y-2', // unordered list classes
     li: 'text-sm md:text-base', // list item classes
     a: 'underline text-blue-500 hover:text-blue-700', // anchor/link classes
-    bold: 'font-medium', // bold/strong classes
-    italic: 'font-italic', // italic/em classes
+    strong: 'font-medium', // bold/strong classes
+    em: 'font-italic', // italic/em classes
   },
 }
 
@@ -95,12 +95,7 @@ convertSchemaToHtml(richTextResponse, options)
 <h1 class="mb-4 text-2xl md:text-4xl">Groceries</h1>
 <p class="mt-3 text-lg">
   Here is my shopping list for various fruit to buy at
-  <a
-    href="https://grocerystore.com"
-    class="underline text-blue-500 hover:text-blue-700"
-  >
-    The Grocery Store
-  </a>
+  <a href="https://grocerystore.com" class="underline text-blue-500 hover:text-blue-700"> The Grocery Store </a>
 </p>
 <ol class="my-3 ml-3 flex flex-col gap-y-2">
   <li class="text-sm md:text-base">apples</li>

--- a/src/index.js
+++ b/src/index.js
@@ -45,90 +45,62 @@ export function convertSchemaToHtml(schema, options = null) {
   return html
 }
 
-export function buildParagraph(el, classes) {
-  if (el?.children && classes?.p) {
-    return `<p class="${classes.p}">${convertSchemaToHtml(el?.children)}</p>`
-  } else if (el?.children) {
-    return `<p>${convertSchemaToHtml(el?.children)}</p>`
+function outputClasses(tag, classes) {
+  if (classes && classes[tag]) {
+    return `class="${classes[tag]}`
+  } else {
+    return ''
   }
+}
+
+function outputAttributes(attributes) {
+  if (!attributes) return ''
+  return Object.keys(attributes)
+    .map(key => {
+      if (attributes[key]) {
+        return `${key}="${attributes[key]}"`
+      }
+    })
+    .join(' ')
+}
+
+function createElement(tag, classes, content, attributes = null) {
+  return `<${tag} ${outputClasses(tag, classes)} ${outputAttributes(attributes)}>${content}</${tag}>`
+}
+
+export function buildParagraph(el, classes) {
+  return createElement('p', classes, convertSchemaToHtml(el?.children))
 }
 
 export function buildHeading(el, classes) {
-  const key = `h${el?.level}`
-  if (el?.children && classes && classes[key]) {
-    return `<h${el?.level} class="${classes[key]}">
-      ${convertSchemaToHtml(el?.children)}
-    </h${el?.level}>`
-  } else if (el?.children) {
-    return `<h${el?.level}>
-      ${convertSchemaToHtml(el?.children)}
-    </h${el?.level}>`
-  }
+  const tag = `h${el?.level}`
+  return createElement(tag, classes, convertSchemaToHtml(el?.children))
 }
 
 export function buildList(el, classes) {
-  if (el?.children) {
-    if (el?.listType === 'ordered') {
-      if (classes?.ol) {
-        return `<ol class="${classes.ol}">
-         ${convertSchemaToHtml(el?.children)}
-        </ol>`
-      } else {
-        return `<ol>${convertSchemaToHtml(el?.children)}</ol>`
-      }
-    } else {
-      if (classes?.ul) {
-        return `<ul class="${classes.ul}">${convertSchemaToHtml(
-          el?.children
-        )}</ul>`
-      } else {
-        return `<ul>${convertSchemaToHtml(el?.children)}</ul>`
-      }
-    }
-  }
+  const tag = el?.listType === 'ordered' ? 'ol' : 'ul'
+  return createElement(tag, classes, convertSchemaToHtml(el?.children))
 }
 
 export function buildListItem(el, classes) {
-  if (el?.children && classes?.li) {
-    return `<li class="${classes.li}">${convertSchemaToHtml(el?.children)}</li>`
-  } else if (el?.children) {
-    return `<li>${convertSchemaToHtml(el?.children)}</li>`
-  }
+  return createElement('li', classes, convertSchemaToHtml(el?.children))
 }
 
 export function buildLink(el, classes) {
-  if (classes?.a) {
-    return `
-    <a href="${el?.url}" 
-       class="${classes.a}" 
-       title="${el?.title}" 
-       target="${el?.target}">
-       ${convertSchemaToHtml(el?.children)}
-    </a>`
-  } else {
-    return `
-    <a href="${el?.url}" 
-       title="${el?.title}" 
-       target="${el?.target}">
-       ${convertSchemaToHtml(el?.children)}
-    </a>`
+  const attributes = {
+    href: el?.url,
+    title: el?.title,
+    target: el?.target,
   }
+  return createElement('a', classes, convertSchemaToHtml(el?.children), attributes)
 }
 
 export function buildText(el, classes) {
   if (el?.bold) {
-    if (classes?.bold) {
-      return `<strong  class="${classes?.bold}">${el?.value}</strong>`
-    } else {
-      return `<strong>${el?.value}</strong>`
-    }
+    return createElement('strong', classes, el?.value)
+  } else if (el?.italic) {
+    return createElement('em', classes, el?.value)
+  } else {
+    return el?.value
   }
-  if (el?.italic) {
-    if (classes?.italic) {
-      return `<em class="${classes.italic}">${el?.value}</em>`
-    } else {
-      return `<em>${el?.value}</em>`
-    }
-  }
-  return el?.value
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 export function convertSchemaToHtml(schema, options = null) {
-  const { scoped, classes } = options ?? {}
+  const { scoped, classes, newLineToBreak } = options ?? {}
   let html = ''
   if (typeof schema === 'string' || schema instanceof String) {
     schema = JSON.parse(schema)
@@ -34,7 +34,7 @@ export function convertSchemaToHtml(schema, options = null) {
           html += buildLink(el, classes)
           break
         case 'text':
-          html += buildText(el, classes)
+          html += buildText(el, classes, newLineToBreak)
           break
         default:
           break
@@ -95,12 +95,12 @@ export function buildLink(el, classes) {
   return createElement('a', classes, convertSchemaToHtml(el?.children, { classes }), attributes)
 }
 
-export function buildText(el, classes) {
+export function buildText(el, classes, newLineToBreak) {
   if (el?.bold) {
     return createElement('strong', classes, el?.value)
   } else if (el?.italic) {
     return createElement('em', classes, el?.value)
   } else {
-    return el?.value
+    return newLineToBreak ? el?.value?.replace(/\n/g, '<br/>') : el?.value
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -54,10 +54,11 @@ function getClass(tag, classes) {
 
 function outputAttributes(attributes) {
   if (!attributes && attributes?.class) return ''
+  const ATTRIBUTE_SEPARATOR = ' '
   return Object.keys(attributes)
     .map(key => {
       if (attributes[key]) {
-        return ` ${key}="${attributes[key]}"`
+        return `${ATTRIBUTE_SEPARATOR}${key}="${attributes[key]}"`
       }
     })
     .join('')

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,11 @@
-export function convertSchemaToHtml(schema, scoped = false) {
+export function convertSchemaToHtml(schema, options = null) {
+  const { scoped, classes } = options ?? {}
+  let html = ''
+
   if (typeof schema === 'string' || schema instanceof String) {
     schema = JSON.parse(schema)
   }
-  let html = ``
+
   if (schema.type === 'root' && schema.children.length > 0) {
     if (scoped) {
       html += `
@@ -17,22 +20,22 @@ export function convertSchemaToHtml(schema, scoped = false) {
     for (const el of schema) {
       switch (el.type) {
         case 'paragraph':
-          html += buildParagraph(el)
+          html += buildParagraph(el, classes)
           break
         case 'heading':
-          html += buildHeading(el)
+          html += buildHeading(el, classes)
           break
         case 'list':
-          html += buildList(el)
+          html += buildList(el, classes)
           break
         case 'list-item':
-          html += buildListItem(el)
+          html += buildListItem(el, classes)
           break
         case 'link':
-          html += buildLink(el)
+          html += buildLink(el, classes)
           break
         case 'text':
-          html += buildText(el)
+          html += buildText(el, classes)
           break
         default:
           break
@@ -42,46 +45,90 @@ export function convertSchemaToHtml(schema, scoped = false) {
   return html
 }
 
-export function buildParagraph(el) {
-  if (el?.children) {
+export function buildParagraph(el, classes) {
+  if (el?.children && classes?.p) {
+    return `<p class="${classes.p}">${convertSchemaToHtml(el?.children)}</p>`
+  } else if (el?.children) {
     return `<p>${convertSchemaToHtml(el?.children)}</p>`
   }
 }
 
-export function buildHeading(el) {
-  if (el?.children) {
-    return `<h${el?.level}>${convertSchemaToHtml(el?.children)}</h${el?.level}>`
+export function buildHeading(el, classes) {
+  const key = `h${el?.level}`
+  if (el?.children && classes && classes[key]) {
+    return `<h${el?.level} class="${classes[key]}">
+      ${convertSchemaToHtml(el?.children)}
+    </h${el?.level}>`
+  } else if (el?.children) {
+    return `<h${el?.level}>
+      ${convertSchemaToHtml(el?.children)}
+    </h${el?.level}>`
   }
 }
 
-export function buildList(el) {
+export function buildList(el, classes) {
   if (el?.children) {
     if (el?.listType === 'ordered') {
-      return `<ol>${convertSchemaToHtml(el?.children)}</ol>`
+      if (classes?.ol) {
+        return `<ol class="${classes.ol}">
+         ${convertSchemaToHtml(el?.children)}
+        </ol>`
+      } else {
+        return `<ol>${convertSchemaToHtml(el?.children)}</ol>`
+      }
     } else {
-      return `<ul>${convertSchemaToHtml(el?.children)}</ul>`
+      if (classes?.ul) {
+        return `<ul class="${classes.ul}">${convertSchemaToHtml(
+          el?.children
+        )}</ul>`
+      } else {
+        return `<ul>${convertSchemaToHtml(el?.children)}</ul>`
+      }
     }
   }
 }
 
-export function buildListItem(el) {
-  if (el?.children) {
+export function buildListItem(el, classes) {
+  if (el?.children && classes?.li) {
+    return `<li class="${classes.li}">${convertSchemaToHtml(el?.children)}</li>`
+  } else if (el?.children) {
     return `<li>${convertSchemaToHtml(el?.children)}</li>`
   }
 }
 
-export function buildLink(el) {
-  return `<a href="${el?.url}" title="${el?.title}" target="${
-    el?.target
-  }">${convertSchemaToHtml(el?.children)}</a>`
+export function buildLink(el, classes) {
+  if (classes?.a) {
+    return `
+    <a href="${el?.url}" 
+       class="${classes.a}" 
+       title="${el?.title}" 
+       target="${el?.target}">
+       ${convertSchemaToHtml(el?.children)}
+    </a>`
+  } else {
+    return `
+    <a href="${el?.url}" 
+       title="${el?.title}" 
+       target="${el?.target}">
+       ${convertSchemaToHtml(el?.children)}
+    </a>`
+  }
 }
 
-export function buildText(el) {
+export function buildText(el, classes) {
   if (el?.bold) {
-    return `<strong>${el?.value}</strong>`
+    if (classes?.bold) {
+      return `<strong  class="${classes?.bold}">${el?.value}</strong>`
+    } else {
+      return `<strong>${el?.value}</strong>`
+    }
   }
   if (el?.italic) {
-    return `<em>${el?.value}</em>`
+    if (classes?.italic) {
+      return `<em class="${classes.italic}">${el?.value}</em>`
+    } else {
+      return `<em>${el?.value}</em>`
+    }
   }
   return el?.value
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 export function convertSchemaToHtml(schema, options = null) {
-  var { scoped, classes } = options ?? {}
+  const { scoped, classes } = options ?? {}
   let html = ''
   if (typeof schema === 'string' || schema instanceof String) {
     schema = JSON.parse(schema)
@@ -44,27 +44,28 @@ export function convertSchemaToHtml(schema, options = null) {
   return html
 }
 
-function outputClasses(tag, classes) {
+function getClass(tag, classes) {
   if (classes && classes[tag]) {
-    return ` class="${classes[tag]}"`
+    return classes[tag]
   } else {
-    return ''
+    return null
   }
 }
 
 function outputAttributes(attributes) {
-  if (!attributes) return ''
+  if (!attributes && attributes?.class) return ''
   return Object.keys(attributes)
     .map(key => {
       if (attributes[key]) {
-        return `${key}="${attributes[key]}"`
+        return ` ${key}="${attributes[key]}"`
       }
     })
-    .join(' ')
+    .join('')
 }
 
-function createElement(tag, classes, content, attributes = null) {
-  return `<${tag}${outputClasses(tag, classes)} ${outputAttributes(attributes)}>${content}</${tag}>`
+function createElement(tag, classes, content, attributes = {}) {
+  attributes = { ...attributes, class: getClass(tag, classes) }
+  return `<${tag}${outputAttributes(attributes)}>${content}</${tag}>`
 }
 
 export function buildParagraph(el, classes) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
-export function convertSchemaToHtml(schema, options = null) {
-  const { scoped, classes, newLineToBreak } = options ?? {}
+export function convertSchemaToHtml(schema, options = {}) {
+  const { scoped } = options
   let html = ''
   if (typeof schema === 'string' || schema instanceof String) {
     schema = JSON.parse(schema)
@@ -19,22 +19,22 @@ export function convertSchemaToHtml(schema, options = null) {
     for (const el of schema) {
       switch (el.type) {
         case 'paragraph':
-          html += buildParagraph(el, classes)
+          html += buildParagraph(el, options)
           break
         case 'heading':
-          html += buildHeading(el, classes)
+          html += buildHeading(el, options)
           break
         case 'list':
-          html += buildList(el, classes)
+          html += buildList(el, options)
           break
         case 'list-item':
-          html += buildListItem(el, classes)
+          html += buildListItem(el, options)
           break
         case 'link':
-          html += buildLink(el, classes)
+          html += buildLink(el, options)
           break
         case 'text':
-          html += buildText(el, classes, newLineToBreak)
+          html += buildText(el, options)
           break
         default:
           break
@@ -69,39 +69,45 @@ function createElement(tag, classes, content, attributes = {}) {
   return `<${tag}${outputAttributes(attributes)}>${content}</${tag}>`
 }
 
-export function buildParagraph(el, classes) {
-  return createElement('p', classes, convertSchemaToHtml(el?.children, { classes }))
+export function buildParagraph(el, options) {
+  const { classes } = options
+  return createElement('p', classes, convertSchemaToHtml(el?.children, options))
 }
 
-export function buildHeading(el, classes) {
+export function buildHeading(el, options) {
+  const { classes } = options
   const tag = `h${el?.level}`
-  return createElement(tag, classes, convertSchemaToHtml(el?.children, { classes }))
+  return createElement(tag, classes, convertSchemaToHtml(el?.children, options))
 }
 
-export function buildList(el, classes) {
+export function buildList(el, options) {
+  const { classes } = options
   const tag = el?.listType === 'ordered' ? 'ol' : 'ul'
-  return createElement(tag, classes, convertSchemaToHtml(el?.children, { classes }))
+  return createElement(tag, classes, convertSchemaToHtml(el?.children, options))
 }
 
-export function buildListItem(el, classes) {
-  return createElement('li', classes, convertSchemaToHtml(el?.children, { classes }))
+export function buildListItem(el, options) {
+  const { classes } = options
+  return createElement('li', classes, convertSchemaToHtml(el?.children, options))
 }
 
-export function buildLink(el, classes) {
+export function buildLink(el, options) {
+  const { classes } = options
   const attributes = {
     href: el?.url,
     title: el?.title,
     target: el?.target,
   }
-  return createElement('a', classes, convertSchemaToHtml(el?.children, { classes }), attributes)
+  return createElement('a', classes, convertSchemaToHtml(el?.children, options), attributes)
 }
 
-export function buildText(el, classes, newLineToBreak) {
+export function buildText(el, options) {
+  const { classes, newLineToBreak } = options
   if (el?.bold) {
     return createElement('strong', classes, el?.value)
   } else if (el?.italic) {
     return createElement('em', classes, el?.value)
   } else {
-    return newLineToBreak ? el?.value?.replace(/\n/g, '<br/>') : el?.value
+    return newLineToBreak ? el?.value?.replace(/\n/g, '<br>') : el?.value
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 export function convertSchemaToHtml(schema, options = null) {
-  const { scoped, classes } = options ?? {}
+  var { scoped, classes } = options ?? {}
   let html = ''
-
   if (typeof schema === 'string' || schema instanceof String) {
     schema = JSON.parse(schema)
   }
@@ -10,11 +9,11 @@ export function convertSchemaToHtml(schema, options = null) {
     if (scoped) {
       html += `
       <div class="${scoped === true ? `rte` : scoped}">
-        ${convertSchemaToHtml(schema.children)}
+        ${(convertSchemaToHtml(schema.children), options)}
       </div>
       `
     } else {
-      html += convertSchemaToHtml(schema.children)
+      html += convertSchemaToHtml(schema.children, options)
     }
   } else {
     for (const el of schema) {
@@ -47,7 +46,7 @@ export function convertSchemaToHtml(schema, options = null) {
 
 function outputClasses(tag, classes) {
   if (classes && classes[tag]) {
-    return `class="${classes[tag]}`
+    return ` class="${classes[tag]}"`
   } else {
     return ''
   }
@@ -65,25 +64,25 @@ function outputAttributes(attributes) {
 }
 
 function createElement(tag, classes, content, attributes = null) {
-  return `<${tag} ${outputClasses(tag, classes)} ${outputAttributes(attributes)}>${content}</${tag}>`
+  return `<${tag}${outputClasses(tag, classes)} ${outputAttributes(attributes)}>${content}</${tag}>`
 }
 
 export function buildParagraph(el, classes) {
-  return createElement('p', classes, convertSchemaToHtml(el?.children))
+  return createElement('p', classes, convertSchemaToHtml(el?.children, { classes }))
 }
 
 export function buildHeading(el, classes) {
   const tag = `h${el?.level}`
-  return createElement(tag, classes, convertSchemaToHtml(el?.children))
+  return createElement(tag, classes, convertSchemaToHtml(el?.children, { classes }))
 }
 
 export function buildList(el, classes) {
   const tag = el?.listType === 'ordered' ? 'ol' : 'ul'
-  return createElement(tag, classes, convertSchemaToHtml(el?.children))
+  return createElement(tag, classes, convertSchemaToHtml(el?.children, { classes }))
 }
 
 export function buildListItem(el, classes) {
-  return createElement('li', classes, convertSchemaToHtml(el?.children))
+  return createElement('li', classes, convertSchemaToHtml(el?.children, { classes }))
 }
 
 export function buildLink(el, classes) {
@@ -92,7 +91,7 @@ export function buildLink(el, classes) {
     title: el?.title,
     target: el?.target,
   }
-  return createElement('a', classes, convertSchemaToHtml(el?.children), attributes)
+  return createElement('a', classes, convertSchemaToHtml(el?.children, { classes }), attributes)
 }
 
 export function buildText(el, classes) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -14,6 +14,8 @@ test('check converting string schema to HTML', () => {
   expect(document.querySelector('h4').textContent).toBe('Heading 4')
   expect(document.querySelector('ul>li').textContent).toBe('item1')
   expect(document.querySelector('p em').textContent).toBe('This is italicized text and ')
+  expect(document.querySelector('a').getAttribute('href')).toBe('https://example.com')
+  expect(document.querySelector('a').getAttribute('title')).toBe('Link to example.com')
 })
 
 test('check converting JSON object schema to HTML', () => {
@@ -69,9 +71,41 @@ test('check converting JSON object schema to HTML', () => {
 
   const html = convertSchemaToHtml(resObject)
   document.body.innerHTML = html
-
+  expect(document.querySelector('a').getAttribute('href')).toBe('https://example.com')
+  expect(document.querySelector('a').getAttribute('title')).toBe('Link to example.com')
   expect(document.querySelector('h1').textContent).toBe('Heading 1')
   expect(document.querySelector('h4').textContent).toBe('Heading 4')
   expect(document.querySelector('ul>li').textContent).toBe('item1')
   expect(document.querySelector('p em').textContent).toBe('This is italicized text and ')
+})
+
+test('check applied classes to elements', () => {
+  const res =
+    '{"type":"root","children":[{"type":"paragraph","children":[{"type":"text","value":"This is italicized text and ","italic":true},{"url":"https://example.com","title":"Link to example.com","type":"link","children":[{"type":"text","value":"a bolded hyperlink","bold":true}]},{"type":"text","value":""}]},{"type":"paragraph","children":[{"type":"text","value":"This is test."}]},{"type":"heading","children":[{"type":"text","value":"Heading 1"}],"level":1},{"listType":"unordered","type":"list","children":[{"type":"list-item","children":[{"type":"text","value":"item1"}]},{"type":"list-item","children":[{"type":"text","value":"item2"}]}]},{"type":"heading","level":4,"children":[{"type":"text","value":"Heading 4"}]},{"listType":"ordered","type":"list","children":[{"type":"list-item","children":[{"type":"text","value":"a"}]},{"type":"list-item","children":[{"type":"text","value":"b"}]},{"type":"list-item","children":[{"type":"text","value":"c"}]}]}]}'
+  const options = {
+    scoped: false,
+    classes: {
+      p: 'mb-3',
+      h1: 'mb-4 text-2xl md:text-4xl',
+      h2: 'mb-4 text-xl md:text-3xl',
+      h3: 'mb-3 text-lg md:text-2xl',
+      h4: 'mb-3 text-base md:text-lg',
+      h5: 'mb-2.5 text-sm md:text-base',
+      h6: 'mb-2 text-xs md:text-sm',
+      ol: 'my-3 ml-3 flex flex-col gap-y-2',
+      ul: 'my-3 ml-3 flex flex-col gap-y-2',
+      li: 'text-sm md:text-base',
+      a: 'underline text-blue-500 hover:text-blue-700',
+      strong: 'font-medium',
+      em: 'font-italic',
+    },
+  }
+  const html = convertSchemaToHtml(res, options)
+  document.body.innerHTML = html
+  expect(document.querySelector('p').className).toBe('mb-3')
+  expect(document.querySelector('h1').className).toBe('mb-4 text-2xl md:text-4xl')
+  expect(document.querySelector('h4').className).toBe('mb-3 text-base md:text-lg')
+  expect(document.querySelector('ul>li').className).toBe('text-sm md:text-base')
+  expect(document.querySelector('p em').className).toBe('font-italic')
+  expect(document.querySelector('p a').className).toBe('underline text-blue-500 hover:text-blue-700')
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -37,7 +37,12 @@ test('check converting JSON object schema to HTML', () => {
       },
       {
         type: 'paragraph',
-        children: [{ type: 'text', value: 'This is test.' }],
+        children: [
+          {
+            type: 'text',
+            value: 'This is test. New\nlines\nare supported.',
+          },
+        ],
       },
       {
         type: 'heading',
@@ -77,6 +82,7 @@ test('check converting JSON object schema to HTML', () => {
   expect(document.querySelector('h4').textContent).toBe('Heading 4')
   expect(document.querySelector('ul>li').textContent).toBe('item1')
   expect(document.querySelector('p em').textContent).toBe('This is italicized text and ')
+  expect(document.querySelector('p:nth-child(2)').innerHTML).toBe('This is test. New<br/>lines<br/>are supported.')
 })
 
 test('check applied classes to elements', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -13,9 +13,7 @@ test('check converting string schema to HTML', () => {
   expect(document.querySelector('h1').textContent).toBe('Heading 1')
   expect(document.querySelector('h4').textContent).toBe('Heading 4')
   expect(document.querySelector('ul>li').textContent).toBe('item1')
-  expect(document.querySelector('p em').textContent).toBe(
-    'This is italicized text and '
-  )
+  expect(document.querySelector('p em').textContent).toBe('This is italicized text and ')
 })
 
 test('check converting JSON object schema to HTML', () => {
@@ -30,9 +28,7 @@ test('check converting JSON object schema to HTML', () => {
             url: 'https://example.com',
             title: 'Link to example.com',
             type: 'link',
-            children: [
-              { type: 'text', value: 'a bolded hyperlink', bold: true },
-            ],
+            children: [{ type: 'text', value: 'a bolded hyperlink', bold: true }],
           },
           { type: 'text', value: '' },
         ],
@@ -77,7 +73,5 @@ test('check converting JSON object schema to HTML', () => {
   expect(document.querySelector('h1').textContent).toBe('Heading 1')
   expect(document.querySelector('h4').textContent).toBe('Heading 4')
   expect(document.querySelector('ul>li').textContent).toBe('item1')
-  expect(document.querySelector('p em').textContent).toBe(
-    'This is italicized text and '
-  )
+  expect(document.querySelector('p em').textContent).toBe('This is italicized text and ')
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -74,7 +74,7 @@ test('check converting JSON object schema to HTML', () => {
     ],
   }
 
-  const html = convertSchemaToHtml(resObject)
+  const html = convertSchemaToHtml(resObject, { newLineToBreak: true })
   document.body.innerHTML = html
   expect(document.querySelector('a').getAttribute('href')).toBe('https://example.com')
   expect(document.querySelector('a').getAttribute('title')).toBe('Link to example.com')
@@ -82,7 +82,7 @@ test('check converting JSON object schema to HTML', () => {
   expect(document.querySelector('h4').textContent).toBe('Heading 4')
   expect(document.querySelector('ul>li').textContent).toBe('item1')
   expect(document.querySelector('p em').textContent).toBe('This is italicized text and ')
-  expect(document.querySelector('p:nth-child(2)').innerHTML).toBe('This is test. New<br/>lines<br/>are supported.')
+  expect(document.querySelector('p:nth-child(2)').innerHTML).toBe('This is test. New<br>lines<br>are supported.')
 })
 
 test('check applied classes to elements', () => {


### PR DESCRIPTION
In this PR, I add a way for developers to apply a string of classes directly to each HTML element. This would be especially useful for developers using an atomic css framework like Tailwind CSS. This change also allows developers to create a wrapper class or component that makes re-using the default classes very easy. 

I also added the request to support converting new line characters to line breaks (`<br/>`). Shopify's rich text editor support creating new lines via `shift + space`.

Example of the new options. Developers can pick and choose which elements they want to apply classes to, but below a list all of the possible elements we can apply classes to.

```javascript
const options = {
  scoped: false,
  newLineToBreak: true,
  classes: {
    p: 'mt-3 text-lg', // paragraph classes
    h1: 'mb-4 text-2xl md:text-4xl', // heading1 classes
    h2: 'mb-4 text-xl md:text-3xl', // heading2 classes
    h3: 'mb-3 text-lg md:text-2xl', // heading3 classes
    h4: 'mb-3 text-base md:text-lg', // heading4 classes
    h5: 'mb-2.5 text-sm md:text-base', // heading5 classes
    h6: 'mb-2 text-xs md:text-sm', // heading6 classes
    ol: 'my-3 ml-3 flex flex-col gap-y-2', // order list classes
    ul: 'my-3 ml-3 flex flex-col gap-y-2', // unordered list classes
    li: 'text-sm md:text-base', // list item classes
    a: 'underline text-blue-500 hover:text-blue-700', // anchor/link classes
    bold: 'font-medium', // bold/strong classes
    italic: 'font-italic', // italic/em classes
  },
}

// Applying classes directly to elements
convertSchemaToHtml(richTextResponse, options)
```

```html
<!-- Output: -->
<h1 class="mb-4 text-2xl md:text-4xl">Groceries</h1>
<p class="mt-3 text-lg">
  Here is my shopping list for various fruit to buy at
  <a
    href="https://grocerystore.com"
    class="underline text-blue-500 hover:text-blue-700"
  >
    The Grocery Store
  </a>
</p>
<ol class="my-3 ml-3 flex flex-col gap-y-2">
  <li class="text-sm md:text-base">apples</li>
  <li class="text-sm md:text-base">oranges</li>
  <li class="text-sm md:text-base">bananas</li>
</ol>
...
```
By utilizing this and a React/Hydrogen component developers can easily set a list of default Tailwind classes for each element. They can then add props to override a certain elements classes for easy reuse throughout their codebase.

``` javascript
import { convertSchemaToHtml } from '@thebeyondgroup/shopify-rich-text-renderer'
...
export default RichTextToHTML({richText, paragraphClasses, boldClasses}){
const p = paragraphClasses ?? 'mt-3 text-lg'
const bold = boldClasses ?? 'font-medium'
const options = {
  scoped: false,
  classes: {
    p,
    bold
  },
}

  return (
   <>
    <div
        className="html"
        dangerouslySetInnerHTML={{
          __html: convertSchemaToHtml(richText, options),
          }}
         />
      <div>
   </>
 )
}
```