### PR TITLE
Update the test cases & allow scoped to be passed instead of the options object

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ convertSchemaToHtml(richTextResponse)
 ...
 ```
 
-To get scoped HTML pass either true or the name of a class(es) to use in your scoped css selectors in the `scoped` property of the `options` parameter (options.scoped). This allows for the rich text HTML to be easily styled.
+To get scoped HTML pass either true or the name of a class(es) to use in your scoped css selectors in the `scoped` property of the `options` parameter (options.scoped). This allows for the rich text HTML to be easily styled. _Note: You can also pass a scoped class name or_ `true`_ (to use default scoped class) instead of the options object, i.e._ `convertSchemaToHtml(richTextResponse, 'rich-text-wrap')`.
 
 ```javascript
 // scoped html
@@ -46,7 +46,7 @@ convertSchemaToHtml(richTextResponse, { scoped: true })
 </div>
 ```
 
-You can also pass in a custom class name to be used as the scoped class instead of the default `rte`
+You can also pass in a custom class name to be used as the scoped class instead of the default `rte`.
 
 ```javascript
 //scoped w/ custom class name

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,12 @@
 export function convertSchemaToHtml(schema, options = {}) {
-  const { scoped } = options
+  let { scoped } = options
   let html = ''
   if (typeof schema === 'string' || schema instanceof String) {
     schema = JSON.parse(schema)
+  }
+
+  if (typeof options === 'string' || options instanceof String || options === true) {
+    scoped = options
   }
 
   if (schema.type === 'root' && schema.children.length > 0) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,10 +4,65 @@
 
 import { convertSchemaToHtml } from '../src/index.js'
 
-test('check converting string schema to HTML', () => {
-  const res =
-    '{"type":"root","children":[{"type":"paragraph","children":[{"type":"text","value":"This is italicized text and ","italic":true},{"url":"https://example.com","title":"Link to example.com","type":"link","children":[{"type":"text","value":"a bolded hyperlink","bold":true}]},{"type":"text","value":""}]},{"type":"paragraph","children":[{"type":"text","value":"This is test."}]},{"type":"heading","children":[{"type":"text","value":"Heading 1"}],"level":1},{"listType":"unordered","type":"list","children":[{"type":"list-item","children":[{"type":"text","value":"item1"}]},{"type":"list-item","children":[{"type":"text","value":"item2"}]}]},{"type":"heading","level":4,"children":[{"type":"text","value":"Heading 4"}]},{"listType":"ordered","type":"list","children":[{"type":"list-item","children":[{"type":"text","value":"a"}]},{"type":"list-item","children":[{"type":"text","value":"b"}]},{"type":"list-item","children":[{"type":"text","value":"c"}]}]}]}'
-  const html = convertSchemaToHtml(res)
+const resString =
+  '{"type":"root","children":[{"type":"paragraph","children":[{"type":"text","value":"This is italicized text and ","italic":true},{"url":"https://example.com","title":"Link to example.com","type":"link","children":[{"type":"text","value":"a bolded hyperlink","bold":true}]},{"type":"text","value":""}]},{"type":"paragraph","children":[{"type":"text","value":"This is test. New\\nlines\\nare supported."}]},{"type":"heading","children":[{"type":"text","value":"Heading 1"}],"level":1},{"listType":"unordered","type":"list","children":[{"type":"list-item","children":[{"type":"text","value":"item1"}]},{"type":"list-item","children":[{"type":"text","value":"item2"}]}]},{"type":"heading","level":4,"children":[{"type":"text","value":"Heading 4"}]},{"listType":"ordered","type":"list","children":[{"type":"list-item","children":[{"type":"text","value":"a"}]},{"type":"list-item","children":[{"type":"text","value":"b"}]},{"type":"list-item","children":[{"type":"text","value":"c"}]}]}]}'
+const resObject = {
+  type: 'root',
+  children: [
+    {
+      type: 'paragraph',
+      children: [
+        { type: 'text', value: 'This is italicized text and ', italic: true },
+        {
+          url: 'https://example.com',
+          title: 'Link to example.com',
+          type: 'link',
+          children: [{ type: 'text', value: 'a bolded hyperlink', bold: true }],
+        },
+        { type: 'text', value: '' },
+      ],
+    },
+    {
+      type: 'paragraph',
+      children: [
+        {
+          type: 'text',
+          value: 'This is test. New\nlines\nare supported.',
+        },
+      ],
+    },
+    {
+      type: 'heading',
+      children: [{ type: 'text', value: 'Heading 1' }],
+      level: 1,
+    },
+    {
+      listType: 'unordered',
+      type: 'list',
+      children: [
+        { type: 'list-item', children: [{ type: 'text', value: 'item1' }] },
+        { type: 'list-item', children: [{ type: 'text', value: 'item2' }] },
+      ],
+    },
+    {
+      type: 'heading',
+      level: 4,
+      children: [{ type: 'text', value: 'Heading 4' }],
+    },
+    {
+      listType: 'ordered',
+      type: 'list',
+      children: [
+        { type: 'list-item', children: [{ type: 'text', value: 'a' }] },
+        { type: 'list-item', children: [{ type: 'text', value: 'b' }] },
+        { type: 'list-item', children: [{ type: 'text', value: 'c' }] },
+      ],
+    },
+  ],
+}
+
+test('check converting schema of type string to HTML', () => {
+  const html = convertSchemaToHtml(resString)
   document.body.innerHTML = html
 
   expect(document.querySelector('h1').textContent).toBe('Heading 1')
@@ -18,63 +73,8 @@ test('check converting string schema to HTML', () => {
   expect(document.querySelector('a').getAttribute('title')).toBe('Link to example.com')
 })
 
-test('check converting JSON object schema to HTML', () => {
-  const resObject = {
-    type: 'root',
-    children: [
-      {
-        type: 'paragraph',
-        children: [
-          { type: 'text', value: 'This is italicized text and ', italic: true },
-          {
-            url: 'https://example.com',
-            title: 'Link to example.com',
-            type: 'link',
-            children: [{ type: 'text', value: 'a bolded hyperlink', bold: true }],
-          },
-          { type: 'text', value: '' },
-        ],
-      },
-      {
-        type: 'paragraph',
-        children: [
-          {
-            type: 'text',
-            value: 'This is test. New\nlines\nare supported.',
-          },
-        ],
-      },
-      {
-        type: 'heading',
-        children: [{ type: 'text', value: 'Heading 1' }],
-        level: 1,
-      },
-      {
-        listType: 'unordered',
-        type: 'list',
-        children: [
-          { type: 'list-item', children: [{ type: 'text', value: 'item1' }] },
-          { type: 'list-item', children: [{ type: 'text', value: 'item2' }] },
-        ],
-      },
-      {
-        type: 'heading',
-        level: 4,
-        children: [{ type: 'text', value: 'Heading 4' }],
-      },
-      {
-        listType: 'ordered',
-        type: 'list',
-        children: [
-          { type: 'list-item', children: [{ type: 'text', value: 'a' }] },
-          { type: 'list-item', children: [{ type: 'text', value: 'b' }] },
-          { type: 'list-item', children: [{ type: 'text', value: 'c' }] },
-        ],
-      },
-    ],
-  }
-
-  const html = convertSchemaToHtml(resObject, { newLineToBreak: true })
+test('check converting schema of type object to HTML', () => {
+  const html = convertSchemaToHtml(resObject, { newLineToBreak: true, scoped: true })
   document.body.innerHTML = html
   expect(document.querySelector('a').getAttribute('href')).toBe('https://example.com')
   expect(document.querySelector('a').getAttribute('title')).toBe('Link to example.com')
@@ -83,19 +83,35 @@ test('check converting JSON object schema to HTML', () => {
   expect(document.querySelector('ul>li').textContent).toBe('item1')
   expect(document.querySelector('p em').textContent).toBe('This is italicized text and ')
   expect(document.querySelector('p:nth-child(2)').innerHTML).toBe('This is test. New<br>lines<br>are supported.')
+  expect(document.querySelector('div').className).toBe('rte')
 })
 
-test('check applied classes to elements', () => {
-  const res =
-    '{"type":"root","children":[{"type":"paragraph","children":[{"type":"text","value":"This is italicized text and ","italic":true},{"url":"https://example.com","title":"Link to example.com","type":"link","children":[{"type":"text","value":"a bolded hyperlink","bold":true}]},{"type":"text","value":""}]},{"type":"paragraph","children":[{"type":"text","value":"This is test."}]},{"type":"heading","children":[{"type":"text","value":"Heading 1"}],"level":1},{"listType":"unordered","type":"list","children":[{"type":"list-item","children":[{"type":"text","value":"item1"}]},{"type":"list-item","children":[{"type":"text","value":"item2"}]}]},{"type":"heading","level":4,"children":[{"type":"text","value":"Heading 4"}]},{"listType":"ordered","type":"list","children":[{"type":"list-item","children":[{"type":"text","value":"a"}]},{"type":"list-item","children":[{"type":"text","value":"b"}]},{"type":"list-item","children":[{"type":"text","value":"c"}]}]}]}'
+test('check passing a scoped class name (string) via the option parameter', () => {
+  const html = convertSchemaToHtml(resObject, 'scoped-rte-wrap')
+  document.body.innerHTML = html
+  const rootChildren = document.querySelector('div.scoped-rte-wrap').children
+
+  expect(document.querySelector('div').getAttribute('class')).toBe('scoped-rte-wrap')
+  expect(document.querySelector('a').getAttribute('href')).toBe('https://example.com')
+  expect(rootChildren.length).toBe(6)
+})
+
+test('check newLineToBreak renders line break elements', () => {
+  const html = convertSchemaToHtml(resObject, { newLineToBreak: true })
+  document.body.innerHTML = html
+  expect(document.querySelector('p:nth-child(2)').innerHTML).toBe('This is test. New<br>lines<br>are supported.')
+  expect(document.querySelector('p:nth-child(2)').textContent.includes('\n')).toBe(false)
+})
+
+test('check class options applied to elements', () => {
   const options = {
     scoped: false,
+    newLineToBreak: false,
     classes: {
       p: 'mb-3',
       h1: 'mb-4 text-2xl md:text-4xl',
       h2: 'mb-4 text-xl md:text-3xl',
       h3: 'mb-3 text-lg md:text-2xl',
-      h4: 'mb-3 text-base md:text-lg',
       h5: 'mb-2.5 text-sm md:text-base',
       h6: 'mb-2 text-xs md:text-sm',
       ol: 'my-3 ml-3 flex flex-col gap-y-2',
@@ -106,12 +122,16 @@ test('check applied classes to elements', () => {
       em: 'font-italic',
     },
   }
-  const html = convertSchemaToHtml(res, options)
+  const html = convertSchemaToHtml(resString, options)
   document.body.innerHTML = html
   expect(document.querySelector('p').className).toBe('mb-3')
   expect(document.querySelector('h1').className).toBe('mb-4 text-2xl md:text-4xl')
-  expect(document.querySelector('h4').className).toBe('mb-3 text-base md:text-lg')
+  expect(document.querySelector('h4').className).toBe('')
+  expect(document.querySelector('h4').getAttributeNames()?.length).toBe(0)
+  expect(document.querySelector('h4').outerHTML).toBe('<h4>Heading 4</h4>')
   expect(document.querySelector('ul>li').className).toBe('text-sm md:text-base')
   expect(document.querySelector('p em').className).toBe('font-italic')
+  expect(document.querySelector('p:nth-child(2)').textContent.includes('\n')).toBe(true)
+  expect(document.querySelector('p:nth-child(2)').textContent.includes('<br>')).toBe(false)
   expect(document.querySelector('p a').className).toBe('underline text-blue-500 hover:text-blue-700')
 })


### PR DESCRIPTION
In this PR, I updated the code to check if the value passed into the options parameter is of type `string` or strictly `true`. This will allow users to update to the most recent package without introducing breaking changes in their code base.

I also updated the test cases to have overall better test coverage that also test for certain options settings and edge cases.