### PR TITLE
Support for bold and italic text simultaneously

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -107,7 +107,9 @@ export function buildLink(el, options) {
 
 export function buildText(el, options) {
   const { classes, newLineToBreak } = options
-  if (el?.bold) {
+  if (el?.bold && el?.italic) {
+    return createElement('strong', classes, createElement('em', classes, el?.value))
+  } else if (el?.bold) {
     return createElement('strong', classes, el?.value)
   } else if (el?.italic) {
     return createElement('em', classes, el?.value)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,14 +5,14 @@
 import { convertSchemaToHtml } from '../src/index.js'
 
 const resString =
-  '{"type":"root","children":[{"type":"paragraph","children":[{"type":"text","value":"This is italicized text and ","italic":true},{"url":"https://example.com","title":"Link to example.com","type":"link","children":[{"type":"text","value":"a bolded hyperlink","bold":true}]},{"type":"text","value":""}]},{"type":"paragraph","children":[{"type":"text","value":"This is test. New\\nlines\\nare supported."}]},{"type":"heading","children":[{"type":"text","value":"Heading 1"}],"level":1},{"listType":"unordered","type":"list","children":[{"type":"list-item","children":[{"type":"text","value":"item1"}]},{"type":"list-item","children":[{"type":"text","value":"item2"}]}]},{"type":"heading","level":4,"children":[{"type":"text","value":"Heading 4"}]},{"listType":"ordered","type":"list","children":[{"type":"list-item","children":[{"type":"text","value":"a"}]},{"type":"list-item","children":[{"type":"text","value":"b"}]},{"type":"list-item","children":[{"type":"text","value":"c"}]}]}]}'
+  '{"type":"root","children":[{"type":"paragraph","children":[{"type":"text","value":"This is italicized text and ","italic":true, "bold":true},{"url":"https://example.com","title":"Link to example.com","type":"link","children":[{"type":"text","value":"a bolded hyperlink","bold":true}]},{"type":"text","value":""}]},{"type":"paragraph","children":[{"type":"text","value":"This is test. New\\nlines\\nare supported."}]},{"type":"heading","children":[{"type":"text","value":"Heading 1"}],"level":1},{"listType":"unordered","type":"list","children":[{"type":"list-item","children":[{"type":"text","value":"item1"}]},{"type":"list-item","children":[{"type":"text","value":"item2"}]}]},{"type":"heading","level":4,"children":[{"type":"text","value":"Heading 4"}]},{"listType":"ordered","type":"list","children":[{"type":"list-item","children":[{"type":"text","value":"a"}]},{"type":"list-item","children":[{"type":"text","value":"b"}]},{"type":"list-item","children":[{"type":"text","value":"c"}]}]}]}'
 const resObject = {
   type: 'root',
   children: [
     {
       type: 'paragraph',
       children: [
-        { type: 'text', value: 'This is italicized text and ', italic: true },
+        { type: 'text', value: 'This is italicized text and ', italic: true, bold: true },
         {
           url: 'https://example.com',
           title: 'Link to example.com',
@@ -101,6 +101,12 @@ test('check newLineToBreak renders line break elements', () => {
   document.body.innerHTML = html
   expect(document.querySelector('p:nth-child(2)').innerHTML).toBe('This is test. New<br>lines<br>are supported.')
   expect(document.querySelector('p:nth-child(2)').textContent.includes('\n')).toBe(false)
+})
+
+test('Check text is bold and italic when both are set to true', () => {
+  const html = convertSchemaToHtml(resObject)
+  document.body.innerHTML = html
+  expect(document.querySelector('p>strong>em').textContent).toBe('This is italicized text and ')
 })
 
 test('check class options applied to elements', () => {


### PR DESCRIPTION
Update text rendering to support both bold and italic styles on the same text node. 

I checked the AST for when both both bold & italic is set on a piece of text from the rich text field on the beyond group site. It outputs like so, meaning we can't rely on recursion to set both italic & bold and instead need to update the text rendering conditional.

``` json
{
    "type": "root",
    "children": [
        {
            "type": "paragraph",
            "children": [
                {
                    "type": "text",
                    "value": "We area"
                },
                {
                    "type": "text",
                    "value": " digital product studio",
                    "bold": true,
                    "italic": true
                },
                {
                    "type": "text",
                    "value": " founded in Los Angeles."
                }
            ]
        }
    ]
}
```

 I added a test case as part of this PR, which sets both bold & italic to true on one text node. The test passes and converted html is shown in the "generated HTML" example below.
 
 **Test case richtext schema input:**
 ``` javascript
 {
  type: 'root',
  children: [
    {
      type: 'paragraph',
      children: [
        { type: 'text', value: 'This is italicized text and ', italic: true, bold: true }
      ]
     ...
    ]
}
```

**Generated HTML from test**

``` html
 <p>
   <strong>
     <em>This is italicized text and </em>
   </strong>
   <a href="https://example.com" title="Link to example.com">
     <strong>a bolded hyperlink</strong>
   </a>
 </p>
...
```

Closes: #37